### PR TITLE
Updating QGL's gantry_corners

### DIFF
--- a/Firmware/Config/printer.cfg
+++ b/Firmware/Config/printer.cfg
@@ -38,7 +38,7 @@ restart_method: command
 
 [printer]
 kinematics: corexy
-max_velocity: 300
+max_velocity: 300  
 max_accel: 3000             #Max 4000
 max_z_velocity: 15          #Max 15 for 12V TMC Drivers, can increase for 24V
 max_z_accel: 350
@@ -57,14 +57,14 @@ dir_pin: !PF12
 enable_pin: !PF14
 rotation_distance: 32
 microsteps: 32
-full_steps_per_rotation:200
+full_steps_per_rotation:200  
 position_min: 0
 position_endstop: 115
 position_max: 115
 homing_positive_dir: true
 endstop_pin: PG6
 homing_retract_dist: 5
-homing_speed: 50   #Max 100
+homing_speed: 50   #Max 100 
 
 
 
@@ -84,14 +84,14 @@ dir_pin: !PG1
 enable_pin: !PF15
 rotation_distance: 32
 microsteps: 32
-full_steps_per_rotation:200
+full_steps_per_rotation:200 
 position_min: 0
 position_endstop: 123
 position_max: 123
 homing_positive_dir: true
-endstop_pin: PG9
+endstop_pin: PG9 
 homing_retract_dist: 5
-homing_speed: 50   #Max 100
+homing_speed: 50   #Max 100 
 
 [tmc2209 stepper_y]
 uart_pin: PD11
@@ -100,8 +100,8 @@ run_current: 0.6
 sense_resistor: 0.110
 stealthchop_threshold: 0
 
-
-
+ 
+ 
 #####################################################################
 #   Z Stepper Settings
 #####################################################################
@@ -324,7 +324,7 @@ gantry_corners:
     177.53, 184.15
 #Probe points
 points:
-    5,5
+   5,5
 	5,80
 	110,80
 	110,5
@@ -342,19 +342,19 @@ max_adjust: 10
 
 [board_pins]
 aliases:
-	# EXP1 header
-	EXP1_1=PE8, EXP1_2=PE7,
-	EXP1_3=PE9, EXP1_4=PE10,
-	EXP1_5=PE12, EXP1_6=PE13,    # Slot in the socket on this side
-	EXP1_7=PE14, EXP1_8=PE15,
-	EXP1_9=<GND>, EXP1_10=<5V>,
+    # EXP1 header
+    EXP1_1=PE8, EXP1_2=PE7,
+    EXP1_3=PE9, EXP1_4=PE10,
+    EXP1_5=PE12, EXP1_6=PE13,    # Slot in the socket on this side
+    EXP1_7=PE14, EXP1_8=PE15,
+    EXP1_9=<GND>, EXP1_10=<5V>,
 
-	# EXP2 header
-	EXP2_1=PA6, EXP2_2=PA5,
-	EXP2_3=PB1, EXP2_4=PA4,
-	EXP2_5=PB2, EXP2_6=PA7,      # Slot in the socket on this side
-	EXP2_7=PC15, EXP2_8=<RST>,
-	EXP2_9=<GND>, EXP2_10=<5V>
+    # EXP2 header
+    EXP2_1=PA6, EXP2_2=PA5,
+    EXP2_3=PB1, EXP2_4=PA4,
+    EXP2_5=PB2, EXP2_6=PA7,      # Slot in the socket on this side
+    EXP2_7=PC15, EXP2_8=<RST>,
+    EXP2_9=<GND>, EXP2_10=<5V>
 
 #####################################################################
 #   Displays
@@ -385,14 +385,14 @@ aliases:
 #initial_BLUE: 0.0
 #color_order: RGB
 
-##  Set RGB values on boot up for each Neopixel.
+##  Set RGB values on boot up for each Neopixel. 
 ##  Index 1 = display, Index 2 and 3 = Knob
 #[delayed_gcode setdisplayneopixel]
 #initial_duration: 1
 #gcode:
 #        SET_LED LED=btt_mini12864 RED=1 GREEN=1 BLUE=1 INDEX=1 TRANSMIT=0
 #        SET_LED LED=btt_mini12864 RED=1 GREEN=0 BLUE=0 INDEX=2 TRANSMIT=0
-#        SET_LED LED=btt_mini12864 RED=1 GREEN=0 BLUE=0 INDEX=3
+#        SET_LED LED=btt_mini12864 RED=1 GREEN=0 BLUE=0 INDEX=3 
 
 #--------------------------------------------------------------------
 
@@ -403,43 +403,43 @@ aliases:
 
 [gcode_macro G32]
 gcode:
-	SAVE_GCODE_STATE NAME=STATE_G32
-	G90
-	G28
-	QUAD_GANTRY_LEVEL
-	G28
-	G0 X57.5 Y61.5 Z30 F3600
-	RESTORE_GCODE_STATE NAME=STATE_G32
-
+    SAVE_GCODE_STATE NAME=STATE_G32
+    G90
+    G28
+    QUAD_GANTRY_LEVEL
+    G28
+    G0 X57.5 Y61.5 Z30 F3600
+    RESTORE_GCODE_STATE NAME=STATE_G32
+   
 [gcode_macro PRINT_START]
 #   Use PRINT_START for the slicer starting script - please customise for your slicer of choice
 gcode:
-	G32                            ; home all axes
-	G90                            ; absolute positioning
-	G1 Z20 F3000                   ; move nozzle away from bed
-
+    G32                            ; home all axes
+    G90                            ; absolute positioning
+    G1 Z20 F3000                   ; move nozzle away from bed
+   
 
 [gcode_macro PRINT_END]
 #   Use PRINT_END for the slicer ending script - please customise for your slicer of choice
 gcode:
-	# safe anti-stringing move coords
-	{% set th = printer.toolhead %}
-	{% set x_safe = th.position.x + 20 * (1 if th.axis_maximum.x - th.position.x > 20 else -1) %}
-	{% set y_safe = th.position.y + 20 * (1 if th.axis_maximum.y - th.position.y > 20 else -1) %}
-	{% set z_safe = [th.position.z + 2, th.axis_maximum.z]|min %}
-
-	SAVE_GCODE_STATE NAME=STATE_PRINT_END
-
-	M400                           ; wait for buffer to clear
-	G92 E0                         ; zero the extruder
-	G1 E-5.0 F1800                 ; retract filament
-
-	TURN_OFF_HEATERS
-
-	G90                                      ; absolute positioning
-	G0 X{x_safe} Y{y_safe} Z{z_safe} F20000  ; move nozzle to remove stringing
-	G0 X{th.axis_maximum.x//2} Y{th.axis_maximum.y - 2} F3600  ; park nozzle at rear
-	M107                                     ; turn off fan
-
-	BED_MESH_CLEAR
-	RESTORE_GCODE_STATE NAME=STATE_PRINT_END
+    # safe anti-stringing move coords
+    {% set th = printer.toolhead %}
+    {% set x_safe = th.position.x + 20 * (1 if th.axis_maximum.x - th.position.x > 20 else -1) %}
+    {% set y_safe = th.position.y + 20 * (1 if th.axis_maximum.y - th.position.y > 20 else -1) %}
+    {% set z_safe = [th.position.z + 2, th.axis_maximum.z]|min %}
+    
+    SAVE_GCODE_STATE NAME=STATE_PRINT_END
+    
+    M400                           ; wait for buffer to clear
+    G92 E0                         ; zero the extruder
+    G1 E-5.0 F1800                 ; retract filament
+    
+    TURN_OFF_HEATERS
+    
+    G90                                      ; absolute positioning
+    G0 X{x_safe} Y{y_safe} Z{z_safe} F20000  ; move nozzle to remove stringing
+    G0 X{th.axis_maximum.x//2} Y{th.axis_maximum.y - 2} F3600  ; park nozzle at rear
+    M107                                     ; turn off fan
+    
+    BED_MESH_CLEAR
+    RESTORE_GCODE_STATE NAME=STATE_PRINT_END

--- a/Firmware/Config/printer.cfg
+++ b/Firmware/Config/printer.cfg
@@ -38,7 +38,7 @@ restart_method: command
 
 [printer]
 kinematics: corexy
-max_velocity: 300  
+max_velocity: 300
 max_accel: 3000             #Max 4000
 max_z_velocity: 15          #Max 15 for 12V TMC Drivers, can increase for 24V
 max_z_accel: 350
@@ -57,14 +57,14 @@ dir_pin: !PF12
 enable_pin: !PF14
 rotation_distance: 32
 microsteps: 32
-full_steps_per_rotation:200  
+full_steps_per_rotation:200
 position_min: 0
 position_endstop: 115
 position_max: 115
 homing_positive_dir: true
 endstop_pin: PG6
 homing_retract_dist: 5
-homing_speed: 50   #Max 100 
+homing_speed: 50   #Max 100
 
 
 
@@ -84,14 +84,14 @@ dir_pin: !PG1
 enable_pin: !PF15
 rotation_distance: 32
 microsteps: 32
-full_steps_per_rotation:200 
+full_steps_per_rotation:200
 position_min: 0
 position_endstop: 123
 position_max: 123
 homing_positive_dir: true
-endstop_pin: PG9 
+endstop_pin: PG9
 homing_retract_dist: 5
-homing_speed: 50   #Max 100 
+homing_speed: 50   #Max 100
 
 [tmc2209 stepper_y]
 uart_pin: PD11
@@ -100,8 +100,8 @@ run_current: 0.6
 sense_resistor: 0.110
 stealthchop_threshold: 0
 
- 
- 
+
+
 #####################################################################
 #   Z Stepper Settings
 #####################################################################
@@ -320,11 +320,11 @@ timeout: 1800
 
 [quad_gantry_level]
 gantry_corners:
-	-50,-4.5
-	170,180
+    -57.53, -9.51      # from Micron CAD Center-of-KGLM03 to bed.
+    177.53, 184.15
 #Probe points
 points:
-   5,5
+    5,5
 	5,80
 	110,80
 	110,5
@@ -342,19 +342,19 @@ max_adjust: 10
 
 [board_pins]
 aliases:
-    # EXP1 header
-    EXP1_1=PE8, EXP1_2=PE7,
-    EXP1_3=PE9, EXP1_4=PE10,
-    EXP1_5=PE12, EXP1_6=PE13,    # Slot in the socket on this side
-    EXP1_7=PE14, EXP1_8=PE15,
-    EXP1_9=<GND>, EXP1_10=<5V>,
+	# EXP1 header
+	EXP1_1=PE8, EXP1_2=PE7,
+	EXP1_3=PE9, EXP1_4=PE10,
+	EXP1_5=PE12, EXP1_6=PE13,    # Slot in the socket on this side
+	EXP1_7=PE14, EXP1_8=PE15,
+	EXP1_9=<GND>, EXP1_10=<5V>,
 
-    # EXP2 header
-    EXP2_1=PA6, EXP2_2=PA5,
-    EXP2_3=PB1, EXP2_4=PA4,
-    EXP2_5=PB2, EXP2_6=PA7,      # Slot in the socket on this side
-    EXP2_7=PC15, EXP2_8=<RST>,
-    EXP2_9=<GND>, EXP2_10=<5V>
+	# EXP2 header
+	EXP2_1=PA6, EXP2_2=PA5,
+	EXP2_3=PB1, EXP2_4=PA4,
+	EXP2_5=PB2, EXP2_6=PA7,      # Slot in the socket on this side
+	EXP2_7=PC15, EXP2_8=<RST>,
+	EXP2_9=<GND>, EXP2_10=<5V>
 
 #####################################################################
 #   Displays
@@ -385,14 +385,14 @@ aliases:
 #initial_BLUE: 0.0
 #color_order: RGB
 
-##  Set RGB values on boot up for each Neopixel. 
+##  Set RGB values on boot up for each Neopixel.
 ##  Index 1 = display, Index 2 and 3 = Knob
 #[delayed_gcode setdisplayneopixel]
 #initial_duration: 1
 #gcode:
 #        SET_LED LED=btt_mini12864 RED=1 GREEN=1 BLUE=1 INDEX=1 TRANSMIT=0
 #        SET_LED LED=btt_mini12864 RED=1 GREEN=0 BLUE=0 INDEX=2 TRANSMIT=0
-#        SET_LED LED=btt_mini12864 RED=1 GREEN=0 BLUE=0 INDEX=3 
+#        SET_LED LED=btt_mini12864 RED=1 GREEN=0 BLUE=0 INDEX=3
 
 #--------------------------------------------------------------------
 
@@ -403,43 +403,43 @@ aliases:
 
 [gcode_macro G32]
 gcode:
-    SAVE_GCODE_STATE NAME=STATE_G32
-    G90
-    G28
-    QUAD_GANTRY_LEVEL
-    G28
-    G0 X57.5 Y61.5 Z30 F3600
-    RESTORE_GCODE_STATE NAME=STATE_G32
-   
+	SAVE_GCODE_STATE NAME=STATE_G32
+	G90
+	G28
+	QUAD_GANTRY_LEVEL
+	G28
+	G0 X57.5 Y61.5 Z30 F3600
+	RESTORE_GCODE_STATE NAME=STATE_G32
+
 [gcode_macro PRINT_START]
 #   Use PRINT_START for the slicer starting script - please customise for your slicer of choice
 gcode:
-    G32                            ; home all axes
-    G90                            ; absolute positioning
-    G1 Z20 F3000                   ; move nozzle away from bed
-   
+	G32                            ; home all axes
+	G90                            ; absolute positioning
+	G1 Z20 F3000                   ; move nozzle away from bed
+
 
 [gcode_macro PRINT_END]
 #   Use PRINT_END for the slicer ending script - please customise for your slicer of choice
 gcode:
-    # safe anti-stringing move coords
-    {% set th = printer.toolhead %}
-    {% set x_safe = th.position.x + 20 * (1 if th.axis_maximum.x - th.position.x > 20 else -1) %}
-    {% set y_safe = th.position.y + 20 * (1 if th.axis_maximum.y - th.position.y > 20 else -1) %}
-    {% set z_safe = [th.position.z + 2, th.axis_maximum.z]|min %}
-    
-    SAVE_GCODE_STATE NAME=STATE_PRINT_END
-    
-    M400                           ; wait for buffer to clear
-    G92 E0                         ; zero the extruder
-    G1 E-5.0 F1800                 ; retract filament
-    
-    TURN_OFF_HEATERS
-    
-    G90                                      ; absolute positioning
-    G0 X{x_safe} Y{y_safe} Z{z_safe} F20000  ; move nozzle to remove stringing
-    G0 X{th.axis_maximum.x//2} Y{th.axis_maximum.y - 2} F3600  ; park nozzle at rear
-    M107                                     ; turn off fan
-    
-    BED_MESH_CLEAR
-    RESTORE_GCODE_STATE NAME=STATE_PRINT_END
+	# safe anti-stringing move coords
+	{% set th = printer.toolhead %}
+	{% set x_safe = th.position.x + 20 * (1 if th.axis_maximum.x - th.position.x > 20 else -1) %}
+	{% set y_safe = th.position.y + 20 * (1 if th.axis_maximum.y - th.position.y > 20 else -1) %}
+	{% set z_safe = [th.position.z + 2, th.axis_maximum.z]|min %}
+
+	SAVE_GCODE_STATE NAME=STATE_PRINT_END
+
+	M400                           ; wait for buffer to clear
+	G92 E0                         ; zero the extruder
+	G1 E-5.0 F1800                 ; retract filament
+
+	TURN_OFF_HEATERS
+
+	G90                                      ; absolute positioning
+	G0 X{x_safe} Y{y_safe} Z{z_safe} F20000  ; move nozzle to remove stringing
+	G0 X{th.axis_maximum.x//2} Y{th.axis_maximum.y - 2} F3600  ; park nozzle at rear
+	M107                                     ; turn off fan
+
+	BED_MESH_CLEAR
+	RESTORE_GCODE_STATE NAME=STATE_PRINT_END


### PR DESCRIPTION
Measuring the latest CAD, here are the accurate values for QGL's gantry_corners:

[quad_gantry_level]
gantry_corners:
    -57.53, -9.51      # from Micron CAD Center-of-KGLM03 to bed.
    177.53, 184.15

This differs ever so slightly from L.e.o.p.a.r.d.'s values:
[quad_gantry_level]
gantry_corners:
    -57.**3**3, -9.51      # from Micron CAD Center-of-KGLM03 to bed.
    177.53, 184.15